### PR TITLE
Fix white space detection

### DIFF
--- a/ocr.go
+++ b/ocr.go
@@ -133,12 +133,14 @@ func (o *OCR) filterAndArrange(all []*fontSymbolLookup) string {
 	var str strings.Builder
 	x := all[0].x
 	cx := 0
-	for _, s := range all {
+	for i, s := range all {
 		maxCX := max(cx, s.fs.width)
 
 		// if distance between end of previous symbol and beginning of the
 		// current is larger then a char size, then it is a space
-		if s.x-x >= maxCX {
+		// This should not be applied in the beginning (i == 0) as it would put a white space for
+		// any s.x > maxCX will have a (useless) whitespace in front
+		if s.x-x >= maxCX && i != 0 {
 			str.WriteString(" ")
 		}
 

--- a/ocr.go
+++ b/ocr.go
@@ -138,7 +138,7 @@ func (o *OCR) filterAndArrange(all []*fontSymbolLookup) string {
 
 		// if distance between end of previous symbol and beginning of the
 		// current is larger then a char size, then it is a space
-		if s.x-(x+cx) >= maxCX {
+		if s.x-x >= maxCX {
 			str.WriteString(" ")
 		}
 


### PR DESCRIPTION
I noticed the white space detection was applying too little. This was happening because:

- We want to add a space whenever the x position (left) of the current symbol is greater than the end x position (right) of the previous symbol
- The `cx`  variable contains the width of the previous symbol
- The `x` variable contains the x position **+ the width** of the previous symbol
- In the if check, we add an additional `cx`  to `x`, which basically means we are adding the width twice.

I removed this double check.