### PR TITLE
Fix JPEG decode instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ Add this library to your project with:
 go get github.com/deluan/lookup
 ```
 
+The Go `image` package only knows about the image formats that you register.
+If you want to decode PNG, JPEG or other formats, remember to import their
+decoders for their side‑effects:
+
+```go
+import (
+    _ "image/png"
+    _ "image/jpeg"
+)
+```
+
+Without these imports calls like `image.Decode` will fail and may result in nil
+images being passed to Lookup.
+
+Passing a `nil` image to Lookup will now panic with a clear message. Make sure
+to check the errors returned by `image.Decode` before using the image.
+
 To learn how to use it, take a look at the example files for [Lookup](examples_lookup_test.go) and 
 [OCR](examples_ocr_test.go). All images used in the examples are available in the [testdata](testdata) folder. 
 For more details check the full [documentation](https://godoc.org/github.com/deluan/lookup).

--- a/examples_lookup_test.go
+++ b/examples_lookup_test.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"os"
 
+	_ "image/jpeg"
 	_ "image/png"
 
 	"github.com/deluan/lookup"
@@ -12,9 +13,16 @@ import (
 
 // Helper function to load an image from the filesystem
 func loadImage(imgPath string) image.Image {
-	imageFile, _ := os.Open(imgPath)
+	imageFile, err := os.Open(imgPath)
+	if err != nil {
+		panic(err)
+	}
 	defer imageFile.Close()
-	img, _, _ := image.Decode(imageFile)
+
+	img, _, err := image.Decode(imageFile)
+	if err != nil {
+		panic(err)
+	}
 	return img
 }
 

--- a/examples_ocr_test.go
+++ b/examples_ocr_test.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"os"
 
+	_ "image/jpeg"
 	_ "image/png"
 
 	"github.com/deluan/lookup"
@@ -12,9 +13,16 @@ import (
 
 // Helper function to load an image from the filesystem
 func loadImageFromFile(imgPath string) image.Image {
-	imageFile, _ := os.Open(imgPath)
+	imageFile, err := os.Open(imgPath)
+	if err != nil {
+		panic(err)
+	}
 	defer imageFile.Close()
-	img, _, _ := image.Decode(imageFile)
+
+	img, _, err := image.Decode(imageFile)
+	if err != nil {
+		panic(err)
+	}
 	return img
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -8,6 +8,9 @@ import (
 // ensureGrayScale is a helper function to convert any image.Image to image.Gray, using a simple
 // average of the color channels. Ignores luminosity.
 func ensureGrayScale(imgSrc image.Image) image.Image {
+	if imgSrc == nil {
+		panic("lookup: received a nil image. Make sure to check errors from image.Decode and import the appropriate image decoder")
+	}
 	if _, ok := imgSrc.(*image.Gray); ok && (imgSrc.Bounds().Min == image.Point{}) {
 		return imgSrc
 	}


### PR DESCRIPTION
## Summary
- clarify that image decoders must be imported
- update examples to register JPEG decoder
- add panic with a clear message when Lookup receives a nil image
- handle errors in the example code

## Testing
- `go test ./...`
