### PR TITLE
Opening up package internals to allow custom fonts/symbols.

### DIFF
--- a/fonts_test.go
+++ b/fonts_test.go
@@ -8,9 +8,9 @@ import (
 )
 
 func TestFontSymbol(t *testing.T) {
-	Convey("When I create a fontSymbol from a image dile", t, func() {
+	Convey("When I create a fontSymbol from a image file", t, func() {
 		img := loadImageGray("testdata/font_1/0.png")
-		fs := newFontSymbol("0", img)
+		fs := NewFontSymbol("0", img)
 		Convey("It loads the image as a imageBinary", func() {
 			So(fs.image, ShouldHaveSameTypeAs, &imageBinary{})
 			So(fs.image.width, ShouldEqual, img.Bounds().Max.X)

--- a/ocr.go
+++ b/ocr.go
@@ -131,15 +131,14 @@ func (o *OCR) filterAndArrange(all []*fontSymbolLookup) string {
 
 	var str strings.Builder
 	x := all[0].x
-	cx := 0
+	previousAdvance := 0
 	for i, s := range all {
-		maxCX := max(cx, s.fs.width)
-
 		// if distance between end of previous symbol and beginning of the
 		// current is larger then a char size, then it is a space
 		// This should not be applied in the beginning (i == 0) as it would put a white space for
 		// any s.x > maxCX will have a (useless) whitespace in front
-		if s.x-x >= maxCX && i != 0 {
+		maxCurrentPreviousAdvance := max(previousAdvance, s.fs.Advance())
+		if s.x-x >= maxCurrentPreviousAdvance && i != 0 {
 			str.WriteString(" ")
 		}
 
@@ -148,8 +147,8 @@ func (o *OCR) filterAndArrange(all []*fontSymbolLookup) string {
 			str.WriteString("\n")
 		}
 
-		x = s.x + s.fs.width
-		cx = s.fs.width
+		x = s.x + s.fs.Advance()
+		previousAdvance = s.fs.Advance()
 		str.WriteString(s.fs.symbol)
 	}
 

--- a/ocr_parallel_find.go
+++ b/ocr_parallel_find.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Search for all symbols in the image in parallel. Uses a Fan-out/fan-in approach.
-func findAllInParallel(numWorkers int, symbols []*fontSymbol, img *imageBinary, threshold float64, rect image.Rectangle) ([]*fontSymbolLookup, error) {
+func findAllInParallel(numWorkers int, symbols []*FontSymbol, img *imageBinary, threshold float64, rect image.Rectangle) ([]*fontSymbolLookup, error) {
 	f := &parallelFinder{
 		numWorkers: max(numWorkers, 1),
 		symbols:    symbols,
@@ -21,7 +21,7 @@ type parallelFinder struct {
 	img        *imageBinary
 	threshold  float64
 	numWorkers int
-	symbols    []*fontSymbol
+	symbols    []*FontSymbol
 	rect       image.Rectangle
 }
 
@@ -30,8 +30,8 @@ type lookupResult struct {
 	err error
 }
 
-func (f *parallelFinder) prepare(done <-chan struct{}) <-chan *fontSymbol {
-	out := make(chan *fontSymbol)
+func (f *parallelFinder) prepare(done <-chan struct{}) <-chan *FontSymbol {
+	out := make(chan *FontSymbol)
 	go func() {
 		defer close(out)
 		for _, s := range f.symbols {
@@ -45,7 +45,7 @@ func (f *parallelFinder) prepare(done <-chan struct{}) <-chan *fontSymbol {
 	return out
 }
 
-func (f *parallelFinder) addWorker(done <-chan struct{}, in <-chan *fontSymbol) <-chan lookupResult {
+func (f *parallelFinder) addWorker(done <-chan struct{}, in <-chan *FontSymbol) <-chan lookupResult {
 	out := make(chan lookupResult)
 	go func() {
 		defer close(out)


### PR DESCRIPTION
- fontSymbol is now public (renamed to FontSymbol).
- newFontSymbol is now public (rename to  NewFontSymbol{,Rune}) for allowing the creation of symbols based on an image.
- Added AddFontFamily and AddSymbols to allow for adding custom fonts/symbols to the OCR lookup.